### PR TITLE
Use `--` for `string *` commands

### DIFF
--- a/functions/__ysu__check_aliases.fish
+++ b/functions/__ysu__check_aliases.fish
@@ -1,20 +1,20 @@
 function __ysu__check_aliases \
         --on-event fish_preexec
-    string match --quiet "sudo *" "$argv"; and return
+    string match --quiet -- "sudo *" "$argv"; and return
 
     set --local found false
     alias | sort | while read entry
-        set entry (string replace "=" "" "$entry")
-        set --local tokens (string split --max 2 " " "$entry")
+        set entry (string replace -- "=" "" "$entry")
+        set --local tokens (string split --max 2 -- " " "$entry")
         set --local key "$tokens[2]"
-        set --local escaped_key (string escape --no-quote --style=regex "$key")
+        set --local escaped_key (string escape --no-quote --style=regex -- "$key")
 
-        string match --quiet --regex "$escaped_key" "$YSU__IGNORED_GLOBAL_ALIASES"; and continue
+        string match --quiet --regex -- "$escaped_key" "$YSU__IGNORED_GLOBAL_ALIASES"; and continue
 
-        set --local value (string replace --regex '(?:[\"|\']([^,]*)[\"|\'])' '$1' "$tokens[3]")
-        set --local escaped_value (string escape --no-quote --style=regex "$value")
+        set --local value (string replace --regex -- '(?:[\"|\']([^,]*)[\"|\'])' '$1' "$tokens[3]")
+        set --local escaped_value (string escape --no-quote --style=regex -- "$value")
 
-        if string match --quiet --regex "(?<=^|\s)$escaped_value(?=\s|\$)" "$argv"
+        if string match --quiet --regex -- "(?<=^|\s)$escaped_value(?=\s|\$)" "$argv"
             __ysu__message "alias" "$value" "$key"
             set found true
         end

--- a/functions/__ysu__check_git_aliases.fish
+++ b/functions/__ysu__check_git_aliases.fish
@@ -1,18 +1,18 @@
 function __ysu__check_git_aliases \
         --on-event fish_preexec
-    string match --quiet "sudo *" "$argv"; and return
+    string match --quiet -- "sudo *" "$argv"; and return
 
-    if string match --quiet --regex "git *" "$argv"
+    if string match --quiet --regex -- "git *" "$argv"
         set --local found false
         git config --get-regexp "^alias\..+\$" | sort | while read key value
-            set key (string split --max 2 "." "$key")[2]
-            set --local escaped_key (string escape --no-quote --style=regex "$key")
+            set key (string split --max 2 -- "." "$key")[2]
+            set --local escaped_key (string escape --no-quote --style=regex -- "$key")
 
-            string match --quiet --regex "$escaped_key" "$YSU__IGNORED_GIT_ALIASES"; and continue
+            string match --quiet --regex -- "$escaped_key" "$YSU__IGNORED_GIT_ALIASES"; and continue
 
-            set --local escaped_value (string escape --no-quote --style=regex "$value")
+            set --local escaped_value (string escape --no-quote --style=regex -- "$value")
 
-            if string match --quiet --regex "git $escaped_value(?=\s|\$)" "$argv"
+            if string match --quiet --regex -- "git $escaped_value(?=\s|\$)" "$argv"
                 __ysu__message "git alias" "$value" "git $key"
                 set found true
             end


### PR DESCRIPTION
`string match`, `string escape` and friends will try to parse any argument that starts with a `-` as a switch.  If a string being processed happens to start with a `-` it will, most likely, cause an "unknown option" error.

Any `string cmd` that uses variables, especially those containing externally provided values, should use `--` to indicate the end of the `string` command switches and start of the positional parameters.

Consider:

```fish
    > string match '*a*b' --axxb
    string match: --axxb: unknown option

    (Type 'help string' for related documentation)

    > string match -- '*a*b' --axxb
    --axxb
```

This is causing real errors, for example, as git aliases may start with a switch for `git` itself, as in

```.gitconfig
[alias]
    dt = --paginate difftool --tool=difft
```